### PR TITLE
Change default object print method

### DIFF
--- a/R/class_FragStat.r
+++ b/R/class_FragStat.r
@@ -18,6 +18,7 @@ setMethod("$", "FragStat", function(x, name) {
 
 setMethod("$<-", "FragStat", function(x, name, value) {
     slot(x, name) <- value
+    invisible(x)
 })
 
 
@@ -36,6 +37,6 @@ setMethod("$<-", "FragStat", function(x, name, value) {
 setMethod("show", "FragStat", function(object) {
     cat("\nFragStat object (Summary Statistics by Step)\n")
     printSlots(object)
-    cat("Use '@' to access the data\n")
+    cat("Use '$attr' to access the data\n")
     invisible(object)
 })

--- a/R/class_FragStat.r
+++ b/R/class_FragStat.r
@@ -21,14 +21,21 @@ setMethod("$<-", "FragStat", function(x, name, value) {
 })
 
 
+# setMethod("show", "FragStat", function(object) {
+#     cat("FragStat object:\n")
+#     printSlotValue(object, "qmatrix")
+#     printSlotValue(object, "cmeansoz")
+#     printSlotValue(object, "cmeansozc")
+#     printSlotValue(object, "csdsoz")
+#     printSlotValue(object, "csdsozc")
+#     cat("Use '$attr' to access the data\n")
+#     
+#     invisible(object)
+# })
+
 setMethod("show", "FragStat", function(object) {
-    cat("FragStat object:\n")
-    printSlotValue(object, "qmatrix")
-    printSlotValue(object, "cmeansoz")
-    printSlotValue(object, "cmeansozc")
-    printSlotValue(object, "csdsoz")
-    printSlotValue(object, "csdsozc")
-    cat("Use '$attr' to access the data\n")
-    
+    cat("\nFragStat object (Summary Statistics by Step)\n")
+    printSlots(object)
+    cat("Use '@' to access the data\n")
     invisible(object)
 })

--- a/R/class_Fragility.r
+++ b/R/class_Fragility.r
@@ -38,6 +38,6 @@ setMethod("$<-", "Fragility", function(x, name, value) {
 setMethod("show", "Fragility", function(object) {
     cat("\nFragility object\n")
     printSlots(object)
-    cat("Use '@' to access the data\n")
+    cat("Use '$attr' to access the data\n")
     invisible(object)
 })

--- a/R/class_Fragility.r
+++ b/R/class_Fragility.r
@@ -22,15 +22,22 @@ setMethod("$<-", "Fragility", function(x, name, value) {
 
 
 ## Define the print method
+# setMethod("show", "Fragility", function(object) {
+#     cat("Fragility object:\n")
+#     printSlotValue(object, "ieegts")
+#     printSlotValue(object, "adj")
+#     printSlotValue(object, "frag")
+#     printSlotValue(object, "frag_ranked")
+#     printSlotValue(object, "R2")
+#     printSlotValue(object, "lambdas")
+#     cat("Use '$attr' to access the data\n")
+#     
+#     invisible(object)
+# })
+
 setMethod("show", "Fragility", function(object) {
-    cat("Fragility object:\n")
-    printSlotValue(object, "ieegts")
-    printSlotValue(object, "adj")
-    printSlotValue(object, "frag")
-    printSlotValue(object, "frag_ranked")
-    printSlotValue(object, "R2")
-    printSlotValue(object, "lambdas")
-    cat("Use '$attr' to access the data\n")
-    
+    cat("\nFragility object\n")
+    printSlots(object)
+    cat("Use '@' to access the data\n")
     invisible(object)
 })

--- a/R/utils.r
+++ b/R/utils.r
@@ -47,3 +47,9 @@ valid_soz <- function( ieegts, sozindex, soznames){
   return(valid)
   
 }
+
+# Shifts to the right all strings of a list with a number of blanks
+shift <- \(strL, nBlanks = 0) {
+  pre <- paste(rep(" ", nBlanks), collapse = "")
+  lapply(strL, \(x) sprintf("%s%s", pre, x)) |> unlist()
+}


### PR DESCRIPTION
The update code modifies the default print method for the objects of the S4 "Fragility" and "FragStat" class
1) Additional member properties
2) Data are aligned
3) The main part of the output is present in table format